### PR TITLE
Fixed documentation when using authentication

### DIFF
--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -258,7 +258,7 @@ PSMDB 3.x target.
    ```
    #mongodump --port 27000 -d admin -o tokumx2_dump
    ```
-   At the end of this process the admin database will be ready to be restored in any MongoDB 3+
+   At the end of this process the admin database will be ready to be restored in any MongoDB 3+.
 
 
 ## Phase 3 - Restore <a name="restore"></a>


### PR DESCRIPTION
Covering authentication and how to upgrade the users.
As the 2.4 users are not compatible with 3.0+ I've added how to upgrade the users to the new standard.